### PR TITLE
Quickfix:

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "dependencies": {
     "component-classes": "^1.2.3",
-    "component-closest": "^0.1.4",
+    "component-closest": "^1.0.1",
     "component-delegate": "^0.2.3",
     "component-event": "^0.1.4",
     "component-matches-selector": "^0.1.5",


### PR DESCRIPTION
Updating component-closest to avoid  Error 
> Error: Cannot find module 'matches-selector'

Change in component-closest can be seen in 
https://github.com/component/closest/commit/aaadbecd8da2e808311cd7ad779c568a3209a9ff

As stated in package-json here: component-matches-selector is imported but matches-selector was used..
So fallback is needed.