### PR TITLE
feat(style): add `assignStyle` utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,10 @@ A minimal dom utility toolbelt. Library friendly and based on utilities provided
 This library is tiny (`2Kb` in size) and still exposes all fundamental utilities:
 
 ```bash
-$ browserify index.js \
-    --standalone=dom \
-    --plugin=tinyify | \
-    gzip > min-dom.min.js.gz
-
-$ du -b *.gz
-1842    min-dom.min.js.gz
+$ npm run distro
+$ gzip dist/min-dom.min.js
+$ du -b dist/*.gz
+2003    min-dom.min.js.gz
 ```
 
 
@@ -24,6 +21,7 @@ $ du -b *.gz
 
 The library exposes the following tiny dom helpers:
 
+* `assignStyle` - add inline styles to a node
 * `attr` - get and set node attributes
 * `classes` - class name helper
 * `clear` - remove children from a node

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -55,7 +55,7 @@ export function domify(dom: string, doc?: HTMLDocument): HTMLElement;
 
 export namespace event {
   export function bind<CType extends Function>(el: EventTarget, type: string, fn: CType, capture?: boolean): CType;
-  export function unbind<CType extends Function>(el: EventTarget , type: string, fn: CType, capture?: boolean): CType;
+  export function unbind<CType extends Function>(el: EventTarget, type: string, fn: CType, capture?: boolean): CType;
 }
 
 export function matches<K extends keyof HTMLElementTagNameMap>(el: HTMLElementTagNameMap[K], selector: K): el is HTMLElementTagNameMap[K];
@@ -70,3 +70,5 @@ export function queryAll<K extends keyof SVGElementTagNameMap>(selectors: K, el?
 export function queryAll<E extends Element = Element>(selectors: string, el?: HTMLElement): NodeListOf<E>;
 
 export function remove(el: Element): void;
+
+export function assignStyle<E extends Element>(element: E, ...styleSources: object): E;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
+export { assign as assignStyle } from './style';
 export { default as attr } from './attr';
 export { default as classes } from './classes';
 export { default as clear } from './clear';

--- a/lib/style.js
+++ b/lib/style.js
@@ -1,0 +1,25 @@
+import { forEach } from 'min-dash';
+
+/**
+ * Assigns style attributes in a style-src compliant way.
+ *
+ * @param {Element} element
+ * @param {...Object} styleSources
+ *
+ * @return {Element} the element
+ */
+export function assign(element, ...styleSources) {
+  const target = element.style;
+
+  forEach(styleSources, function(style) {
+    if (!style) {
+      return;
+    }
+
+    forEach(style, function(value, key) {
+      target[key] = value;
+    });
+  });
+
+  return element;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4645,6 +4645,11 @@
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
+    "min-dash": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
+      "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
+    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "component-event": "^0.1.4",
     "domify": "^1.3.1",
     "indexof": "0.0.1",
-    "matches-selector": "^1.2.0"
+    "matches-selector": "^1.2.0",
+    "min-dash": "^3.8.1"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",

--- a/test/style.js
+++ b/test/style.js
@@ -1,0 +1,34 @@
+import {
+  domify,
+  assignStyle
+} from '../lib';
+
+
+describe('style', function() {
+
+  it('should assign styles', function() {
+
+    // given
+    var node = domify('<div class="foo" style="width: 0px; height: 0px; z-index: 0"></div>');
+
+    var style1 = {
+      height: '1px',
+      zIndex: '1'
+    };
+
+    var style2 = {
+      zIndex: '2'
+    };
+
+    // when
+    assignStyle(node, style1, style2);
+
+    // then
+    var appliedStyle = node.style;
+    expect(appliedStyle).to.exist;
+    expect(appliedStyle.width).to.eql('0px');
+    expect(appliedStyle.height).to.eql('1px');
+    expect(appliedStyle.zIndex).to.eql('2');
+  });
+
+});


### PR DESCRIPTION
This PR adds a utility for CSP-compliant manipulation of the element style.

related to https://github.com/bpmn-io/bpmn-js/issues/1625

Draft-PRs integrating this feature:
https://github.com/bpmn-io/bpmn-js/pull/1645
https://github.com/bpmn-io/diagram-js/pull/636

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
