### PR TITLE
fix: correctly reexport `component-event`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [min-dom](https://github.com/bpmn-io/min-dom) are documen
 
 ___Note:__ Yet to be released changes appear here._
 
+## 4.0.2
+
+* `FIX`: correctly reexport `component-event` ([#18](https://github.com/bpmn-io/min-dom/pull/18))
+
 ## 4.0.1
 
 * `CHORE`: remove unnecessary deps, script, and .babelrc

--- a/lib/event.js
+++ b/lib/event.js
@@ -1,3 +1,3 @@
-export {
-  default
-} from 'component-event';
+import * as event from 'component-event';
+
+export default event;

--- a/test/integration/karma.conf.js
+++ b/test/integration/karma.conf.js
@@ -10,7 +10,9 @@ module.exports = function(karma) {
 
     files: [
       'dist/min-dom.min.js',
-      'test/integration/*.js'
+      'test/integration/umd.js',
+      { pattern: 'test/integration/module.js', type: 'module' },
+      { pattern: 'dist/index.esm.js', included: false }
     ],
 
     reporters: [ 'progress' ],

--- a/test/integration/module.js
+++ b/test/integration/module.js
@@ -1,0 +1,46 @@
+import {
+  domify,
+  queryAll,
+  remove,
+  event
+} from '../../dist/index.esm.js';
+
+
+describe('module export', function() {
+
+  it('should expose utilities', function() {
+    expect(domify).to.exist;
+    expect(queryAll).to.exist;
+    expect(remove).to.exist;
+    expect(event).to.exist;
+  });
+
+
+  it('should work', function() {
+
+    // when
+    var node = domify('<div class="foo"><div class="bar"></div></div>');
+
+    // then
+    expect(node).to.exist;
+
+    // when
+    document.body.appendChild(node);
+    remove(node);
+
+    // then
+    expect(node.parentNode).not.to.exist;
+
+    // when
+    var bars = queryAll('.bar', node);
+
+    expect(bars).to.have.length(1);
+
+    var fn = () => {};
+
+    // when
+    event.bind(node, 'click', fn);
+    event.unbind(node, 'click', fn);
+  });
+
+});

--- a/test/integration/umd.js
+++ b/test/integration/umd.js
@@ -5,11 +5,13 @@ describe('umd bundle', function() {
   var domify = MinDom.domify;
   var queryAll = MinDom.queryAll;
   var remove = MinDom.remove;
+  var event = MinDom.event;
 
   it('should expose utilities', function() {
     expect(domify).to.exist;
     expect(queryAll).to.exist;
     expect(remove).to.exist;
+    expect(event).to.exist;
   });
 
 
@@ -32,6 +34,12 @@ describe('umd bundle', function() {
     var bars = queryAll('.bar', node);
 
     expect(bars).to.have.length(1);
+
+    var fn = () => {};
+
+    // when
+    event.bind(node, 'click', fn);
+    event.unbind(node, 'click', fn);
   });
 
 });


### PR DESCRIPTION
Related to https://github.com/bpmn-io/bpmn-js-properties-panel/pull/795#issuecomment-1262202104