### PR TITLE
Draft: Update component-event to 0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.0.3",
       "license": "MIT",
       "dependencies": {
-        "component-event": "^0.1.4",
+        "component-event": "^0.2.1",
         "domify": "^1.4.1",
         "min-dash": "^4.0.0"
       },
@@ -1441,9 +1441,9 @@
       "dev": true
     },
     "node_modules/component-event": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/component-event/-/component-event-0.1.4.tgz",
-      "integrity": "sha512-GMwOG8MnUHP1l8DZx1ztFO0SJTFnIzZnBDkXAj8RM2ntV2A6ALlDxgbMY1Fvxlg6WPQ+5IM/a6vg4PEYbjg/Rw=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/component-event/-/component-event-0.2.1.tgz",
+      "integrity": "sha512-wGA++isMqiDq1jPYeyv2as/Bt/u+3iLW0rEa+8NQ82jAv3TgqMiCM+B2SaBdn2DfLilLjjq736YcezihRYhfxw=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -7273,9 +7273,9 @@
       "dev": true
     },
     "component-event": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/component-event/-/component-event-0.1.4.tgz",
-      "integrity": "sha512-GMwOG8MnUHP1l8DZx1ztFO0SJTFnIzZnBDkXAj8RM2ntV2A6ALlDxgbMY1Fvxlg6WPQ+5IM/a6vg4PEYbjg/Rw=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/component-event/-/component-event-0.2.1.tgz",
+      "integrity": "sha512-wGA++isMqiDq1jPYeyv2as/Bt/u+3iLW0rEa+8NQ82jAv3TgqMiCM+B2SaBdn2DfLilLjjq736YcezihRYhfxw=="
     },
     "concat-map": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "license": "MIT",
   "sideEffects": false,
   "dependencies": {
-    "component-event": "^0.1.4",
+    "component-event": "^0.2.1",
     "domify": "^1.4.1",
     "min-dash": "^4.0.0"
   },


### PR DESCRIPTION
Since component-event was missing a license attribute in its package.json there was no WebJAR available. With the latest update, the license is set and the WebJAR is available in the Maven repository. Unfortunately min-dom is relying on component-event 1.4, so it's still not possible to use it as a dependency in a Maven project. This should be fixed by this PR.